### PR TITLE
fix: /search-files download_url 加入 API_SERVER_BASE_URL 前綴（LINE 檔案 404 修復）

### DIFF
--- a/scripts/api_server.py
+++ b/scripts/api_server.py
@@ -337,11 +337,12 @@ class APIHandler(BaseHTTPRequestHandler):
             finally:
                 conn.close()
 
+            _base_url = os.environ.get("API_SERVER_BASE_URL", "").rstrip("/")
             results = [
                 {
                     "file_name": row[0],
                     "file_path": row[1],
-                    "download_url": f"/files/{urllib.parse.quote(row[0], safe='')}",
+                    "download_url": f"{_base_url}/files/{urllib.parse.quote(row[0], safe='')}",
                 }
                 for row in rows
             ]


### PR DESCRIPTION
## Description
新增  環境變數支援，讓  回傳的  變成 LINE 用戶可存取的絕對 URL。

## Fixes
Fixes #58

## Changes
- :  中的  從  改為 

## Before / After
**修改前：**


**修改後：**


## 使用方式
在  設定：


## Bot Execution Log
- ClaudeCode: 自動分析並修復（直接 patch 模式）
