### PR TITLE
fix: vector-search min_sim 0.5→0.3，新增 file_name 篩選（fixes #64）

### DIFF
--- a/scripts/api_server.py
+++ b/scripts/api_server.py
@@ -162,10 +162,10 @@ class APIHandler(BaseHTTPRequestHandler):
             self.send_json(500, {"valid": False, "error": "line_verify.py returned non-JSON"})
 
     def _handle_vector_search(self, data: dict):
-        """POST /vector-search  {question, top_k?, min_sim?, department?} -> {chunks, count}
+        """POST /vector-search  {question, top_k?, min_sim?, department?, file_name?} -> {chunks, count}
 
-        Note: --file-name argument was removed from vector_search.py (PR #45).
-        File-specific searches should use /search-files instead.
+        Supports optional file_name filter to narrow search to a specific document.
+        Default min_sim lowered to 0.3 to reduce false negatives for Chinese embeddings.
         """
         question = data.get("question", "")
         if not question:
@@ -173,8 +173,9 @@ class APIHandler(BaseHTTPRequestHandler):
             return
 
         top_k = str(int(data.get("top_k", 5)))
-        min_sim = str(float(data.get("min_sim", 0.5)))
+        min_sim = str(float(data.get("min_sim", 0.3)))  # lowered from 0.5: Chinese embeddings typically score lower
         department = str(data.get("department", ""))
+        file_name = str(data.get("file_name", ""))
 
         args = [
             sys.executable, str(_SCRIPT_DIR / "vector_search.py"),
@@ -184,6 +185,8 @@ class APIHandler(BaseHTTPRequestHandler):
         ]
         if department:
             args += ["--department", department]
+        if file_name:
+            args += ["--file", file_name]
 
         result = self.run_script(args)
 


### PR DESCRIPTION
## Description
降低 /vector-search 的 min_sim 預設值（0.5 → 0.3），並新增 file_name 篩選參數支援，解決 LINE Bot 回報「知料庫沒有資料」問題。

## Fixes
Fixes #64

## Changes
- `scripts/api_server.py`

## Before / After
**Before:** min_sim 預設 0.5，中文嵌入相似度通常低於此值，導致有資料也被過濾為「無相關資料」。且不支援 file_name 參數，無法針對特定 PDF 進行搜尋。

**After:** min_sim 降為 0.3，減少 false negative；新增 file_name 支援，n8n 可傳入具體檔名（如「面積計算式.pdf」）縮小搜尋範圍。

## Bot Execution Log
- ClaudeCode: 自動分析並修復（人工介入，因 Issue #64 描述過於簡短，Claude CLI 無法判斷修改位置）
