### PR TITLE
fix: lower vector_search min_sim 0.5->0.3 (QA recall improvement)

### DIFF
--- a/workflows/qa_workflow.json
+++ b/workflows/qa_workflow.json
@@ -203,7 +203,7 @@
         "sendBody": true,
         "contentType": "raw",
         "rawContentType": "application/json",
-        "body": "={{ JSON.stringify({question: $json.messageText || '', top_k: 5, min_sim: $json.askFileName ? 0.2 : 0.5, file_name: $json.askFileName || ''}) }}",
+        "body": "={{ JSON.stringify({question: $json.messageText || '', top_k: 5, min_sim: $json.askFileName ? 0.2 : 0.3, file_name: $json.askFileName || ''}) }}",
         "options": {
           "timeout": 60000
         }


### PR DESCRIPTION
## Description
向量搜尋相似度門檻從 0.5 降至 0.3，解決「知識庫沒有資料」的假陰性問題。

## Root Cause
`qa_workflow.json` 的 `Execute: vector_search` 節點在一般 QA 模式下使用 `min_sim: 0.5`，
但 bge-m3 中文向量的相似度分數普遍偏低，導致文件存在於知識庫卻因低於門檻而回傳空結果，
讓 LLM 誤報「目前知識庫中沒有相關資料」。

## Changes
- `workflows/qa_workflow.json`: `min_sim: $json.askFileName ? 0.2 : 0.5` → `min_sim: $json.askFileName ? 0.2 : 0.3`

## Before / After
- **Before**: 詢問「A5坪數總共幾坪」→ 向量搜尋 min_sim=0.5 → 0 結果 → LLM 回「知識庫無資料」
- **After**: 詢問「A5坪數總共幾坪」→ 向量搜尋 min_sim=0.3 → 取得相關 chunks → 正確回答

Fixes #50
Fixes #66