### PR TITLE
fix: LINE 多檔同時上傳掉檔 — line_download_content 改用 $json (#76)

### DIFF
--- a/workflows/qa_workflow.json
+++ b/workflows/qa_workflow.json
@@ -851,12 +851,12 @@
         "sendBody": true,
         "contentType": "raw",
         "rawContentType": "application/json",
-        "body": "={{ JSON.stringify({ message_id: $('Intent Router').first().json.messageId || '', file_name: $('Intent Router').first().json.fileName || '' }) }}",
+        "body": "={{ JSON.stringify({ message_id: $json.messageId || '', file_name: $json.fileName || '' }) }}",
         "options": {
           "timeout": 60000
         }
       },
-      "notes": "file_upload branch: download user-uploaded file from LINE Content API, save under inbox/<BUCKET>/."
+      "notes": "file_upload branch: download user-uploaded file from LINE Content API, save under inbox/<BUCKET>/. MUST use $json (per-item) not $('Intent Router').first() — multi-file uploads emit N items and .first() collapses them all onto the first event's messageId."
     },
     {
       "id": "qa-node-041",


### PR DESCRIPTION
Closes #76

## 問題

`Execute: line_download_content` 節點 body 寫死了 `$('Intent Router').first().json.messageId/fileName`。當使用者一次上傳多個檔案、LINE 把多個 events 塞進同一個 webhook delivery 時，`Parse Message` emit N 個 items → HTTP 節點被觸發 N 次 → 但每次都用**第一個** event 的 messageId 去打 LINE Content API。其餘 N−1 個檔案的 messageId 沒被使用就過期了。

下游 `forward_mail` 因附件路徑相同被去重、`ingest_file_upload` 因 SHA-256 dedup 直接擋掉重複，所以**整批只有第一份檔案進系統**；但 `Build Upload Reply` 用 `itemMatching` 取 per-item filename，使回覆訊息看起來像每個檔案都被處理了，造成 silent data loss。

## 修復

```diff
- \"body\": \"={{ JSON.stringify({ message_id: \$('Intent Router').first().json.messageId || '', file_name: \$('Intent Router').first().json.fileName || '' }) }}\"
+ \"body\": \"={{ JSON.stringify({ message_id: \$json.messageId || '', file_name: \$json.fileName || '' }) }}\"
```

`Route File Upload` IF 的 TRUE 輸出已經把 Check Auth 過後的 per-item payload 帶下來，`\$json.messageId` / `\$json.fileName` 就是當前 item 的正確值。同時把節點 notes 補上「禁止用 .first()」的警語，避免日後改寫又踩進去。

## 為什麼其他 .first() 不需要改

掃過整份 workflow，剩下的 `$('...').first()` 全部位於 QA / 文字找檔 分支，那邊的觸發都是「使用者送一條文字訊息」→ 單一 item，`.first()` 與 `$json` 等價。**只有 file_upload 分支才會 N items per execution**，所以這次只動這一處。

## 驗收測試

1. LINE app **multi-select** 5 個不同 PDF 一次傳送
2. **預期**：
   - LINE 收到的回覆數 = LINE 實際拆出的 webhook delivery 數（≤ 5），每條 ✅ 對應正確檔名
   - mail 收到的附件總數 = 5（可能跨多封信，視 LINE 怎麼切批次）
   - DB `documents` 表新增 5 筆**hash 不同**的紀錄
3. **失敗條件**：附件總數 < 5、DB 新增 < 5 筆

## 檔案

- `workflows/qa_workflow.json` 第 854 行（`Execute: line_download_content` body）

🤖 Generated with [Claude Code](https://claude.com/claude-code)