### PR TITLE
fix: api_server 改用 ThreadingHTTPServer (#78)

### DIFF
--- a/scripts/api_server.py
+++ b/scripts/api_server.py
@@ -32,7 +32,7 @@ import argparse
 import subprocess
 import traceback
 import urllib.parse
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 
 _SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -753,7 +753,8 @@ def main():
     parser.add_argument("--port", type=int, default=8765)
     args = parser.parse_args()
 
-    server = HTTPServer((args.host, args.port), APIHandler)
+    server = ThreadingHTTPServer((args.host, args.port), APIHandler)
+    server.daemon_threads = True
     sys.stderr.write(f"[api_server] Listening on http://{args.host}:{args.port}\n")
     sys.stderr.write(f"[api_server] Endpoints: GET /health /list-inbox /files/<name>  POST /line-verify /vector-search /prompt-builder /search-files /ingest-file /backup-db /line-download-content /forward-mail\n")
     sys.stderr.flush()


### PR DESCRIPTION
Closes #78

## 問題

#76 修好 LINE workflow 的 \`.first()\` 鎖定第一個 event 後，重新驗收 5 個 PDF 同時上傳：
- 修復前：2/5 成功
- 修復後：3/5 成功（仍掉 2 個）

兩個失敗的 n8n execution 都卡在 api_server 的 HTTP 呼叫上：
- ID 646: \`Execute: line_verify\` → \`ECONNABORTED — connection aborted\`
- ID 647: \`Execute: line_download_content\` → \`timeout of 60000ms exceeded\`

根因是 \`scripts/api_server.py\` 用單執行緒 \`HTTPServer\`，多 webhook 同時打進來時請求被序列化，慢的 \`/ingest-file\`（embed + DB write，可達數十秒）會把後面的 \`/line-verify\`（n8n 設 10s timeout）擠爆。10 個 PDF 同時上傳預期會更嚴重。

## 修復

```diff
- from http.server import HTTPServer, BaseHTTPRequestHandler
+ from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
...
- server = HTTPServer((args.host, args.port), APIHandler)
+ server = ThreadingHTTPServer((args.host, args.port), APIHandler)
+ server.daemon_threads = True
```

\`ThreadingHTTPServer\` 是 Python 3.7+ stdlib（\`socketserver.ThreadingMixIn + HTTPServer\`），無新依賴。每個 request 起一條 thread，慢的不阻塞快的。\`daemon_threads=True\` 確保 server 關閉時 worker 不拖住進程。

## Thread safety 已驗證

- \`APIHandler\` 是 stateless（每 request 一個 fresh instance），無共享狀態
- 模組層級全域變數（\`FILES_BASE_DIR\` / \`_SCRIPT_DIR\` / \`_PROJECT_ROOT\`）只讀
- DB 連線在每個 handler 內 \`psycopg2.connect\` 各自開（line 228, 318），thread 之間不共用
- \`subprocess.run\` / \`smtplib\` / \`urllib\` / Ollama HTTP 都是 thread-safe per-call

## 已知次要 race（暫不在此 PR 處理）

\`_handle_line_download_content\` line 622-625 有 \`os.path.exists\` 檢查再 \`open(..., 'wb')\` 的 TOCTOU。兩個 thread 同時下載同名檔案時，最壞情況一份覆寫另一份；後續 SHA-256 dedup 在 DB 層擋掉重複，不會造成 data corruption。等真的觀察到再開單獨 issue 處理。

## 驗收測試

1. PR merge 後重啟 api_server（殺掉 \`scripts/api_server.py\` 進程，重新 \`start_api_server.bat\`）
2. LINE app **multi-select 10 個不同 PDF** 一次上傳
3. **預期**：
   - DB \`documents\` 表新增 10 筆 hash 不同的紀錄
   - mail 收到附件總數 = 10
   - **0 個 ECONNABORTED / 0 個 60s timeout**
4. 同時觀察 \`api_server.log\` 應看到並行的 \`/ingest-file\` 請求 timestamp 重疊

## 檔案

- \`scripts/api_server.py:35\`（import）
- \`scripts/api_server.py:756\`（server boot）

🤖 Generated with [Claude Code](https://claude.com/claude-code)