### PR TITLE
fix: LINE upload robustness — ingest timeout 300s + Gmail 25MB 自動分批 (#80)

### DIFF
--- a/scripts/api_server.py
+++ b/scripts/api_server.py
@@ -644,12 +644,19 @@ class APIHandler(BaseHTTPRequestHandler):
     # Forward a local file as email attachment via SMTP
     # ------------------------------------------------------------------
 
+    # Gmail SMTP hard limit is 25MB per message (after base64 encoding).
+    # Base64 inflates by ~33%, so 18MB raw → ~24MB encoded, leaving 1MB headroom for headers/body.
+    MAIL_BATCH_MAX_BYTES = 18 * 1024 * 1024
+
     def _handle_forward_mail(self, data: dict):
         """POST /forward-mail {file_path | file_paths, subject?, body?, to?} -> {success, ...}
 
-        Sends one email with one OR multiple files attached over SMTP.
-        Accepts either `file_path` (string, single file) or `file_paths` (array, multiple files in one mail).
+        Sends N emails with attachments over SMTP. Multiple files are bin-packed into batches
+        each ≤ MAIL_BATCH_MAX_BYTES so we never hit Gmail's 25MB-per-message limit.
+
+        Accepts either `file_path` (string) or `file_paths` (array).
         Defaults: to=FORWARD_MAIL_TO, subject auto-built from filename(s), body listing files.
+        Subject for batched sends auto-suffixed with `(i/N)`.
         """
         import smtplib
         import ssl
@@ -676,6 +683,17 @@ class APIHandler(BaseHTTPRequestHandler):
             self.send_json(404, {"error": "File(s) not found", "missing": missing})
             return
 
+        # Reject single oversized files — they can't be split.
+        oversized = [(os.path.basename(p), os.path.getsize(p)) for p in paths
+                     if os.path.getsize(p) > self.MAIL_BATCH_MAX_BYTES]
+        if oversized:
+            self.send_json(413, {
+                "success": False,
+                "error": f"File(s) exceed Gmail SMTP per-message limit ({self.MAIL_BATCH_MAX_BYTES // (1024*1024)}MB raw)",
+                "oversized": [{"name": n, "size": s} for n, s in oversized],
+            })
+            return
+
         smtp_host = os.environ.get("SMTP_HOST", "smtp.gmail.com").strip()
         smtp_port = int(os.environ.get("SMTP_PORT", "587"))
         smtp_user = os.environ.get("SMTP_USER", "").strip()
@@ -691,35 +709,63 @@ class APIHandler(BaseHTTPRequestHandler):
             self.send_json(400, {"error": "No recipient (set FORWARD_MAIL_TO in .env or pass `to`)"})
             return
 
-        file_names = [os.path.basename(p) for p in paths]
-        if len(paths) == 1:
-            default_subject = f"LINE 轉寄: {file_names[0]}"
-            default_body = f"由 LINE Bot 自動轉寄\n檔名: {file_names[0]}"
-        else:
-            default_subject = f"LINE 轉寄: {file_names[0]} 等 {len(paths)} 份檔案"
-            default_body = "由 LINE Bot 自動轉寄\n附件清單:\n" + "\n".join(f"  - {n}" for n in file_names)
-
-        subject = str(data.get("subject", "")).strip() or default_subject
-        body = str(data.get("body", "")).strip() or default_body
-
-        msg = EmailMessage()
-        msg["From"] = smtp_user
-        msg["To"] = recipient
-        msg["Subject"] = subject
-        msg.set_content(body)
-
+        # Bin-pack files into batches each ≤ MAIL_BATCH_MAX_BYTES (greedy, keeps original order).
+        batches = []
+        cur_paths = []
+        cur_size = 0
         for p in paths:
-            ctype, _ = mimetypes.guess_type(p)
-            if ctype is None:
-                ctype = "application/octet-stream"
-            maintype, subtype = ctype.split("/", 1)
-            try:
-                with open(p, "rb") as f:
-                    msg.add_attachment(f.read(), maintype=maintype, subtype=subtype, filename=os.path.basename(p))
-            except Exception as e:
-                self.send_json(500, {"error": f"Failed to read attachment {p}: {e}"})
-                return
+            sz = os.path.getsize(p)
+            if cur_paths and cur_size + sz > self.MAIL_BATCH_MAX_BYTES:
+                batches.append(cur_paths)
+                cur_paths = []
+                cur_size = 0
+            cur_paths.append(p)
+            cur_size += sz
+        if cur_paths:
+            batches.append(cur_paths)
 
+        file_names = [os.path.basename(p) for p in paths]
+        user_subject = str(data.get("subject", "")).strip()
+        user_body = str(data.get("body", "")).strip()
+
+        def build_message(batch_paths, batch_idx):
+            batch_names = [os.path.basename(p) for p in batch_paths]
+            if user_subject:
+                subj = user_subject
+            elif len(paths) == 1:
+                subj = f"LINE 轉寄: {file_names[0]}"
+            else:
+                subj = f"LINE 轉寄: {file_names[0]} 等 {len(paths)} 份檔案"
+            if len(batches) > 1:
+                subj = f"{subj} ({batch_idx}/{len(batches)})"
+
+            if user_body:
+                body_text = user_body
+            elif len(paths) == 1:
+                body_text = f"由 LINE Bot 自動轉寄\n檔名: {file_names[0]}"
+            else:
+                body_text = "由 LINE Bot 自動轉寄\n附件清單:\n" + "\n".join(f"  - {n}" for n in file_names)
+            if len(batches) > 1:
+                body_text += f"\n\n(此為第 {batch_idx}/{len(batches)} 封；本批附件:\n" + \
+                             "\n".join(f"  - {n}" for n in batch_names) + ")"
+
+            m = EmailMessage()
+            m["From"] = smtp_user
+            m["To"] = recipient
+            m["Subject"] = subj
+            m.set_content(body_text)
+            for p in batch_paths:
+                ctype, _ = mimetypes.guess_type(p)
+                if ctype is None:
+                    ctype = "application/octet-stream"
+                maintype, subtype = ctype.split("/", 1)
+                with open(p, "rb") as f:
+                    m.add_attachment(f.read(), maintype=maintype, subtype=subtype, filename=os.path.basename(p))
+            return m, subj
+
+        sent_files = []
+        sent_subjects = []
+        failed_batches = []
         try:
             ctx = ssl.create_default_context()
             with smtplib.SMTP(smtp_host, smtp_port, timeout=30) as server:
@@ -727,19 +773,38 @@ class APIHandler(BaseHTTPRequestHandler):
                 server.starttls(context=ctx)
                 server.ehlo()
                 server.login(smtp_user, smtp_password)
-                server.send_message(msg)
+                for i, batch in enumerate(batches, 1):
+                    try:
+                        m, subj = build_message(batch, i)
+                        server.send_message(m)
+                        sent_files.extend(os.path.basename(p) for p in batch)
+                        sent_subjects.append(subj)
+                    except Exception as e:
+                        traceback.print_exc(file=sys.stderr)
+                        failed_batches.append({
+                            "batch": i,
+                            "files": [os.path.basename(p) for p in batch],
+                            "error": str(e),
+                        })
         except Exception as e:
             traceback.print_exc(file=sys.stderr)
-            self.send_json(502, {"success": False, "error": f"SMTP send failed: {e}"})
+            self.send_json(502, {
+                "success": False,
+                "error": f"SMTP connection failed: {e}",
+                "batch_count": len(batches),
+            })
             return
 
         self.send_json(200, {
-            "success": True,
+            "success": len(failed_batches) == 0,
             "to": recipient,
-            "subject": subject,
+            "subject": sent_subjects[0] if sent_subjects else "",
             "file_names": file_names,
             "attachment_count": len(paths),
             "total_size": sum(os.path.getsize(p) for p in paths),
+            "batch_count": len(batches),
+            "sent_files": sent_files,
+            "failed_batches": failed_batches,
         })
 
 

--- a/workflows/qa_workflow.json
+++ b/workflows/qa_workflow.json
@@ -928,11 +928,11 @@
         "rawContentType": "application/json",
         "body": "={{ JSON.stringify({ file_path: $json.file_path || '', department: 'general' }) }}",
         "options": {
-          "timeout": 180000
+          "timeout": 300000
         }
       },
       "continueOnFail": true,
-      "notes": "Run normal ingest pipeline (extract → chunk → embed → write_to_db) + move to processed/. Reads $json.file_path from upstream (Forward Mail Batch preserves it). continueOnFail so reply still runs."
+      "notes": "Run normal ingest pipeline (extract → chunk → embed → write_to_db) + move to processed/. Reads $json.file_path from upstream (Forward Mail Batch preserves it). continueOnFail so reply still runs. Timeout 300s aligned with cron ingest_workflow_v2 (scanned PDFs with OCR + bge-m3 embed can run >3min)."
     },
     {
       "id": "qa-node-043",


### PR DESCRIPTION
Closes #80

延伸自 #76 / #78 — concurrency 問題已解，但 5-PDF 驗收揭露了兩個 robustness 邊界，合在一個 PR 處理。

## 變更 1: qa_workflow.json — ingest timeout 180s → 300s

\`\`\`diff
- "timeout": 180000
+ "timeout": 300000
\`\`\`

對齊 \`workflows/ingest_workflow_v2.json:105\` hourly cron 的設定。實測 4MB 的塗銷後謄本.pdf 在 LINE 路徑跑 180s timeout 失敗，cron 接手也不見得能在 5min 內收工，但 LINE 路徑用 3min 連最基本的命中率都拿不到。

## 變更 2: \`_handle_forward_mail\` — Gmail 25MB 自動分批

Gmail SMTP 一封信 25MB 硬上限（含 base64 編碼後）。Base64 inflate ~33%，所以原始檔總和 > 18MB 就會 \`552 5.3.4 Message size exceeds fixed limit\`。

### 行為改動

| 情境 | 舊 | 新 |
|------|----|----|
| 單檔 > 18MB | 寄出，被 Gmail 拒 → SMTPDataError | **413** 立刻拒，response 列出 oversized 檔案 |
| 多檔總和 > 18MB | 一封信塞爆，被 Gmail 拒 → 全失敗 | **bin-pack 分批**，每批 ≤ 18MB，發 N 封信 |
| 多檔總和 ≤ 18MB | 一封信 N 附件 | 一封信 N 附件（行為不變）|

### Subject / Body 改動

- 單批寄出（總和 ≤ 18MB）：完全保留原本格式
- 多批寄出：subject 後綴 \`(i/N)\`，body 加一段「(此為第 i/N 封；本批附件: ...)」清單

### Response 新增欄位

\`\`\`json
{
  \"success\": true,                          // 全部 batch 都成功才 true
  \"to\": \"...\",
  \"subject\": \"...\",
  \"file_names\": [...],                      // 所有檔（含失敗 batch 的）
  \"attachment_count\": 5,                    // 維持原語意 = 總附件數
  \"total_size\": 23456789,
  \"batch_count\": 2,                         // 新
  \"sent_files\": [...],                      // 新：實際成功寄出的
  \"failed_batches\": [{batch:i, files:[], error:\"...\"}]  // 新：失敗 batch 清單
}
\`\`\`

\`Build Upload Reply\` 在 workflow 端讀的還是 \`mailResp.success / .to / .attachment_count\`，**不需要改**。

### 為什麼不改 \`Build Upload Reply\` 顯示 batch_count

Reply 訊息維持「✉ 已轉寄至：xxx@... (合併 N 份附件)」即可——使用者只關心「我寄的東西收到了沒」，分幾封信對他來說是內部實作細節。如果 \`failed_batches\` 非空（部分失敗），\`success\` 變 false → reply 自動切到「⚠️ 轉寄郵件失敗」分支，error 訊息會帶出來。

## Thread safety

- 在 \`_handle_forward_mail\` 內所有變數都是 local（沒新增 module-level state）
- 一個 SMTP connection 串多個 batch 的 send 是線性的（同一 thread 內），不需要 lock
- \`MAIL_BATCH_MAX_BYTES\` class constant 只讀

## Bin-packer 驗證

local 跑了 6 個邊界測試：

| case | sizes | expected | got |
|------|-------|----------|-----|
| 單檔小 | [1MB] | 1 batch | ✅ 1 |
| 5×5MB | [5,5,5,5,5]MB | 2 batches | ✅ 2 |
| 5×1MB | [1]×5 | 1 batch | ✅ 1 |
| 邊界 18MB | [18MB] | 1 batch | ✅ 1 |
| 19MB oversized | [19MB] | REJECT | ✅ REJECT |
| 2×10MB | [10,10]MB | 2 batches | ✅ 2 |

## 驗收測試（merge 後）

1. **timeout**: 同樣 4MB 掃描 PDF 重傳，預期 ingest_file_upload **不再超時**，DB 新增 1 筆 hash 6e72... 不同的紀錄
2. **size guard 單檔**:
   \`\`\`bash
   curl -X POST http://localhost:8765/forward-mail \
     -d \"{\\\"file_paths\\\":[\\\"/path/to/20mb.pdf\\\"]}\"
   \`\`\`
   預期 \`413\` + \`oversized\` 清單
3. **size guard 多檔**: 拼 5 個 5MB 檔（共 25MB）打 \`/forward-mail\`，預期 mailbox 收到 2 封信，subject 分別 \`...(1/2)\` / \`...(2/2)\`，response \`batch_count: 2 / success: true\`

## 部署

PR merge 後需要：
1. 重啟 api_server（pythonw 進程）→ 載入新 \`_handle_forward_mail\`
2. 容器內 \`n8n import:workflow\` → 載入新 timeout
3. n8n web UI **deactivate → activate**（讓 webhook 重新註冊）

🤖 Generated with [Claude Code](https://claude.com/claude-code)